### PR TITLE
Ajout de la licence MIT

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,9 @@
+MIT License
+
+Copyright (c) The PLX Contributors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -64,4 +64,9 @@ We have designed a ...
 [Git repository of this website](https://github.com/plx-pdg/plx-pdg.github.io) -
 [Development documentation](/book/dev.html)
 
+<div class="oranda-hide"><!-- To avoid inclusion in the landing page... -->
 
+### License
+The PLX website is released under the [MIT license](LICENSE).
+
+</div>


### PR DESCRIPTION
Cette licence ne sera intégrée au projet qu’après avoir reçu la signature de l'accord "Publication du projet PLX sous licence libre" et l'approbation des PRs ouvertes, par tous les membres du projet, ainsi que la permission écrite de la HEIG-VD.
